### PR TITLE
WarcCdxWriter: normalize URL of redirect target location

### DIFF
--- a/src/java/org/commoncrawl/util/WarcWriter.java
+++ b/src/java/org/commoncrawl/util/WarcWriter.java
@@ -109,8 +109,8 @@ public class WarcWriter {
 
   public WarcWriter(final OutputStream out) {
     this.origOut = this.out = out;
-    isoDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    isoDate.setTimeZone(TimeZone.getTimeZone("GMT"));
+    isoDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT);
+    isoDate.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
   /**


### PR DESCRIPTION
Convert the redirect target location into an absolute URL and normalize the URL using the URL normalizer configured for scope "fetcher" before storing it as field "redirect" in the CDX file.

This PR fixes a regression introduced with commoncrawl/nutch@b3b78bb: redirect targets are not converted to absolute URLs. However, also [normalization](https://en.wikipedia.org/wiki/URI_normalization) is required. Otherwise the redirect URLs in the URL index may include various representations of equivalent host names (upper/lower case, IDNs), or even different forms of URL path and query. Only URL normalization makes it possible to reliably follow redirects in the URL index.

Minor change: create all instances of SimpleDateFormat using the ROOT locale, and use the timezone "UTC" consistently.

