### PR TITLE
Detect canonical links in Fetcher

### DIFF
--- a/conf/nutch-default.xml
+++ b/conf/nutch-default.xml
@@ -1180,6 +1180,15 @@
 </property>
 
 <property>
+  <name>fetcher.detect.canonical.link</name>
+  <value>false</value>
+  <description>If true, fetcher will detect canonical links in HTML content
+  relying on the class org.commoncrawl.util.CanonicalLinkDetector. Found
+  links are store in CrawlDatum metadata as &quot;canonical.link&quot;.
+  </description>
+</property>
+
+<property>
   <name>fetcher.timelimit.mins</name>
   <value>-1</value>
   <description>This is the number of minutes allocated to the fetching.

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -101,7 +101,7 @@
 		  crawler-commons, downgraded to commons-io 2.8.0 shipped by Hadoop 3.3.6
 		  https://github.com/commoncrawl/crawler-commons/tree/commons-io-downgrade
 		-->
-		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.6-SNAPSHOT" />
+		<dependency org="com.github.crawler-commons" name="crawler-commons" rev="1.7-SNAPSHOT" />
 
 		<dependency org="com.google.code.gson" name="gson" rev="2.13.1"/>
 		<dependency org="com.martinkl.warc" name="warc-hadoop" rev="0.1.0">

--- a/ivy/ivy.xml
+++ b/ivy/ivy.xml
@@ -146,6 +146,7 @@
         <!-- Required for JUnit 5 (Jupiter) test execution -->
         <dependency org="org.junit.jupiter" name="junit-jupiter-engine" rev="5.13.4" conf="test->default"/>
         <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.13.4" conf="test->default"/>
+        <dependency org="org.junit.jupiter" name="junit-jupiter-params" rev="5.13.4" conf="test->default"/>
 
 		<!-- Jetty used to serve test pages for unit tests, but is also provided as dependency of Hadoop -->
 		<dependency org="org.eclipse.jetty" name="jetty-server" rev="10.0.25" conf="test->default">

--- a/src/java/org/apache/nutch/fetcher/FetcherThread.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherThread.java
@@ -67,6 +67,7 @@ import org.apache.nutch.scoring.ScoringFilters;
 import org.apache.nutch.service.NutchServer;
 import org.apache.nutch.util.StringUtil;
 import org.apache.nutch.util.URLUtil;
+import org.commoncrawl.util.CanonicalLinkDetector;
 import org.commoncrawl.util.WarcCapture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -750,6 +751,17 @@ public class FetcherThread extends Thread {
           byte[] signature = SignatureFactory.getSignature(conf)
               .calculate(content, new ParseStatus().getEmptyParse(conf));
           datum.setSignature(signature);
+        }
+        boolean extractCanonicalLink = true; // TODO: make configurable
+        if (parseResult == null && !parsing && extractCanonicalLink) {
+          List<String> canonicalLinks = CanonicalLinkDetector.detectCanonicalLinks(content);
+          if (!canonicalLinks.isEmpty()) {
+            LOG.debug("Found canonical links: {}", canonicalLinks);
+            // TODO
+            // - resolve, normalize and filter
+            // - add to metadata of datum
+            //   datum.getMetaData().put("", canonicalLinks.get(0));
+          }
         }
       }
 

--- a/src/java/org/apache/nutch/fetcher/FetcherThread.java
+++ b/src/java/org/apache/nutch/fetcher/FetcherThread.java
@@ -31,7 +31,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.nutch.crawl.CrawlDatum;
 import org.apache.nutch.crawl.NutchWritable;
@@ -81,6 +83,8 @@ public class FetcherThread extends Thread {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
+
+  private static Writable EMPTY_VALUE = NullWritable.get();
 
   private Configuration conf;
   private URLFilters urlFilters;
@@ -141,6 +145,7 @@ public class FetcherThread extends Thread {
   private boolean storingProtocolVersions;
 
   private boolean signatureWithoutParsing;
+  private boolean detectCanonicalLink;
 
   private AtomicInteger pages;
 
@@ -180,6 +185,8 @@ public class FetcherThread extends Thread {
     this.parseUtil = new ParseUtil(conf);
     this.skipTruncated = conf.getBoolean(ParseSegment.SKIP_TRUNCATED, true);
     this.signatureWithoutParsing = conf.getBoolean("fetcher.signature", false);
+    this.detectCanonicalLink = conf.getBoolean("fetcher.detect.canonical.link",
+        false);
     this.protocolFactory = new ProtocolFactory(conf);
     this.normalizers = new URLNormalizers(conf, URLNormalizers.SCOPE_FETCHER);
     this.maxCrawlDelay = conf.getInt("fetcher.max.crawl.delay", 30) * 1000;
@@ -752,16 +759,13 @@ public class FetcherThread extends Thread {
               .calculate(content, new ParseStatus().getEmptyParse(conf));
           datum.setSignature(signature);
         }
-        boolean extractCanonicalLink = true; // TODO: make configurable
-        if (parseResult == null && !parsing && extractCanonicalLink) {
-          List<String> canonicalLinks = CanonicalLinkDetector.detectCanonicalLinks(content);
-          if (!canonicalLinks.isEmpty()) {
-            LOG.debug("Found canonical links: {}", canonicalLinks);
-            // TODO
-            // - resolve, normalize and filter
-            // - add to metadata of datum
-            //   datum.getMetaData().put("", canonicalLinks.get(0));
-          }
+
+        if (detectCanonicalLink) {
+          /*
+           * TODO: if parsing, then canonical links should be detected on the
+           * DOM tree.
+           */
+          addCanonicalLink(key, datum, content);
         }
       }
 
@@ -948,6 +952,37 @@ public class FetcherThread extends Thread {
     return null;
   }
   
+  private void addCanonicalLink(Text key, CrawlDatum datum, Content content) {
+    List<String> canonicalLinks = CanonicalLinkDetector
+        .detectCanonicalLinks(content);
+    if (canonicalLinks.isEmpty() || canonicalLinks.get(0).isEmpty()) {
+      /*
+       * Add a null value, so that a CrawlDb update overwrites outdated
+       * canonical links.
+       */
+      datum.getMetaData().put(Nutch.CANONICAL_LINK_KEY, EMPTY_VALUE);
+    } else {
+      LOG.debug("Found canonical links: {}", canonicalLinks);
+      String link = canonicalLinks.get(0);
+      String urlKey = key.toString();
+      try {
+        if (!link.startsWith("http")) {
+          link = URLUtil.resolveURL(new URL(urlKey), link).toString();
+        }
+        link = normalizers.normalize(link, URLNormalizers.SCOPE_FETCHER);
+        // do not filter, we just recording the canonical link
+      } catch (MalformedURLException e) {
+        link = null;
+      }
+      if (link != null) {
+        Text canonicalLink = new Text(link);
+        datum.getMetaData().put(Nutch.CANONICAL_LINK_KEY, canonicalLink);
+      } else {
+        datum.getMetaData().put(Nutch.CANONICAL_LINK_KEY, EMPTY_VALUE);
+      }
+    }
+  }
+
   private void outputRobotsTxt(List<Content> robotsTxtContent) throws InterruptedException {
     for (Content robotsTxt : robotsTxtContent) {
       LOG.debug("Fetched and stored robots.txt {}",

--- a/src/java/org/apache/nutch/metadata/Nutch.java
+++ b/src/java/org/apache/nutch/metadata/Nutch.java
@@ -17,6 +17,7 @@
 package org.apache.nutch.metadata;
 
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 
 /**
  * A collection of Nutch internal metadata constants.
@@ -114,4 +115,6 @@ public interface Nutch {
 	public static final String FETCH_EVENT_FETCHTIME = "fetchTime";
 	/** Content-lanueage key in the Pub/Sub event metadata for the content-language of the parsed page*/
 	public static final String FETCH_EVENT_CONTENTLANG = "content-language";
+
+  public static final Writable CANONICAL_LINK_KEY = new Text("canonical.link");
 }

--- a/src/java/org/commoncrawl/util/ByteArrayCharSequence.java
+++ b/src/java/org/commoncrawl/util/ByteArrayCharSequence.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commoncrawl.util;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Wrap a byte array as a {@link CharSequence} in
+ * {@link StandardCharsets#ISO_8859_1} encoding.
+ * 
+ * For regular expression matching on ASCII characters only, the wrapper should
+ * be faster than creating a {@link String} from the byte array or a
+ * subsequence, because no bytes are converted to chars and no memory is
+ * allocated for a new String.
+ * 
+ * Similar wrappers are part of
+ * <a href="https://extjwnl.sourceforge.net/">extJWNL</a>,
+ * <a href="https://github.com/LAW-Unimi/BUbiNG">BUbiNG</a>, and other Java
+ * libraries.
+ */
+public class ByteArrayCharSequence implements CharSequence {
+
+  private final byte[] data;
+  private final int length;
+  private final int offset;
+
+  public ByteArrayCharSequence() {
+    this(new byte[0], 0, 0);
+  }
+
+  public ByteArrayCharSequence(final byte[] data) {
+    this(data, 0, data.length);
+  }
+
+  public ByteArrayCharSequence(final byte[] data, int length) {
+    this(data, 0, length);
+  }
+
+  public ByteArrayCharSequence(final byte[] data, int offset, int length) {
+    this.data = data;
+    if (offset < 0) {
+      throw new ArrayIndexOutOfBoundsException("Negative offset: " + offset);
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException("Negative length:" + length);
+    }
+    if ((offset + length) > data.length) {
+      throw new ArrayIndexOutOfBoundsException(
+          "(Offset + length) > array_length");
+    }
+    this.length = length;
+    this.offset = offset;
+  }
+
+  @Override
+  public int length() {
+    return this.length;
+  }
+
+  @Override
+  public char charAt(int index) {
+    if (index >= length) {
+      throw new IndexOutOfBoundsException("" + index);
+    }
+    return (char) (data[offset + index] & 0xff);
+  }
+
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return new ByteArrayCharSequence(data, offset + start, end - start);
+  }
+
+  @Override
+  public String toString() {
+    return new String(data, offset, length, StandardCharsets.ISO_8859_1);
+  }
+}

--- a/src/java/org/commoncrawl/util/CanonicalLinkDetector.java
+++ b/src/java/org/commoncrawl/util/CanonicalLinkDetector.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commoncrawl.util;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HeaderElement;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicHeaderValueParser;
+import org.apache.nutch.protocol.Content;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CanonicalLinkDetector {
+
+  protected static Set<String> SUPPORTED_CONTENT_TYPES = new HashSet<>();
+  static {
+    SUPPORTED_CONTENT_TYPES.add("text/html");
+    SUPPORTED_CONTENT_TYPES.add("application/xhtml+xml");
+  }
+
+  /**
+   * Pattern to match canonical link elements in HTML. The length of the
+   * canonical link URL inside the element is limited to max. 2048 characters.
+   */
+  private static Pattern canonicalLinkPattern = Pattern.compile(
+      "<link\\s+[^>]{0,2054}rel=(?:'canonical'|\"canonical\"|canonical\\b)[^>]{0,2054}>",
+      Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+  private static Pattern hrefPattern = Pattern
+      .compile("href=['\"]?([^'\"\\s]{0,2048})", Pattern.CASE_INSENSITIVE);
+
+  private static Pattern canonicalRelValuePattern = Pattern
+      .compile("\\bcanonical\\b", Pattern.CASE_INSENSITIVE);
+  private static final Pattern linkInParentheses = Pattern
+      .compile("^\\s*<\\s*(.*?)\\s*>\\s*$");
+
+  private static final List<String> EMPTY_RESULT = List.of();
+
+  /** top-N bytes of HTML to look for canonical link */
+  private static int CHUNK_SIZE = 65536;
+
+  /** max. number canonical links to detect */
+  private static int MAX_LINKS = 1;
+
+  /**
+   * Extract canonical link from HTTP header.
+   * 
+   * The extraction is delegated to {@link BasicHeaderValueParser} because
+   * parsing multi-valued link attributes is far from trivial, e.g.
+   * 
+   * <pre>
+   Link: <https://frontera.library.ucla.edu/songs>; rel="canonical",<https://frontera.library.ucla.edu/songs>; rel="shortlink",<https://frontera.library.ucla.edu/favicon.ico>; rel="shortcut icon"
+   * </pre>
+   * 
+   * @param &quot;Link&quot;
+   *          header values
+   * @return the canonical links found, or an empty list if no canonical link is
+   *         found
+   */
+  protected static List<String> detectCanonicalLinksHttpHeader(
+      String[] linkHeaders, int maxResults) {
+    List<String> result = EMPTY_RESULT;
+    for (String httpHeaderLink : linkHeaders) {
+      HeaderElement elem = BasicHeaderValueParser
+          .parseHeaderElement(httpHeaderLink, BasicHeaderValueParser.INSTANCE);
+      for (NameValuePair param : elem.getParameters()) {
+        if ("rel".equalsIgnoreCase(param.getName())
+            && canonicalRelValuePattern.matcher(param.getValue()).find()) {
+          String link = elem.getName();
+          // match inside < ... >
+          Matcher urlMatcher = linkInParentheses.matcher(link);
+          if (urlMatcher.matches()) {
+            link = urlMatcher.group(1);
+            if (result == EMPTY_RESULT) {
+              result = new ArrayList<String>(1);
+            }
+            result.add(link);
+            if (result.size() >= maxResults) {
+              break;
+            }
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  public static boolean isEligibleContentType(String contentType) {
+    return SUPPORTED_CONTENT_TYPES.contains(contentType);
+  }
+
+  /**
+   * Extract canonical link from HTTP header.
+   * 
+   * The extraction is delegated to {@link BasicHeaderValueParser} because
+   * parsing multi-valued link attributes is far from trivial, e.g.
+   * 
+   * <pre>
+   Link: <https://frontera.library.ucla.edu/songs>; rel="canonical",<https://frontera.library.ucla.edu/songs>; rel="shortlink",<https://frontera.library.ucla.edu/favicon.ico>; rel="shortcut icon"
+   * </pre>
+   * 
+   * @param &quot;Link&quot;
+   *          header values
+   * @return the canonical links found, or an empty list if no canonical link is
+   *         found
+   */
+  public static List<String> detectCanonicalLinksHTML(byte[] content, int chunkSize,
+      int maxResults) {
+    List<String> result = EMPTY_RESULT;
+    int length = content.length < chunkSize ? content.length : chunkSize;
+    CharSequence cs;
+    cs = new ByteArrayCharSequence(content, length);
+    Matcher clMatcher = canonicalLinkPattern.matcher(cs);
+    while (clMatcher.find()) {
+      CharSequence cls;
+      cls = cs.subSequence(clMatcher.start(), clMatcher.end());
+      Matcher hrefMatcher = hrefPattern.matcher(cls);
+      if (hrefMatcher.find(5)) {
+        String cl = hrefMatcher.group(1);
+        if (result == EMPTY_RESULT) {
+          result = new ArrayList<String>(1);
+        }
+        result.add(cl);
+        if (result.size() >= maxResults) {
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
+  public static List<String> detectCanonicalLinks(Content content,
+      int chunkSize, int maxLinks) {
+
+    /*
+     * Note: the HTTP header look-up is case-insensitive if
+     * CaseInsensitiveMetadata or SpellCheckedMetadata is used.
+     */
+    String[] linkHeaders = content.getMetadata().getValues("Link");
+    List<String> canonicalLinks = detectCanonicalLinksHttpHeader(linkHeaders,
+        maxLinks);
+
+    if (canonicalLinks.size() < maxLinks
+        && isEligibleContentType(content.getContentType())) {
+      List<String> linksHtml = detectCanonicalLinksHTML(content.getContent(), chunkSize, maxLinks);
+      if (linksHtml.size() > 0) {
+        if (canonicalLinks == EMPTY_RESULT) {
+          canonicalLinks = linksHtml;
+        } else {
+          canonicalLinks.addAll(linksHtml);
+        }
+      }
+    }
+    return canonicalLinks;
+  }
+
+  public static List<String> detectCanonicalLinks(Content content) {
+    return detectCanonicalLinks(content, CHUNK_SIZE, MAX_LINKS);
+  }
+
+}

--- a/src/java/org/commoncrawl/util/CanonicalLinkDetector.java
+++ b/src/java/org/commoncrawl/util/CanonicalLinkDetector.java
@@ -26,12 +26,16 @@ import java.util.regex.Pattern;
 
 import org.apache.http.HeaderElement;
 import org.apache.http.NameValuePair;
+import org.apache.http.ParseException;
 import org.apache.http.message.BasicHeaderValueParser;
 import org.apache.nutch.protocol.Content;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CanonicalLinkDetector {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(MethodHandles.lookup().lookupClass());
 
   protected static Set<String> SUPPORTED_CONTENT_TYPES = new HashSet<>();
   static {
@@ -81,8 +85,14 @@ public class CanonicalLinkDetector {
       String[] linkHeaders, int maxResults) {
     List<String> result = EMPTY_RESULT;
     for (String httpHeaderLink : linkHeaders) {
-      HeaderElement elem = BasicHeaderValueParser
-          .parseHeaderElement(httpHeaderLink, BasicHeaderValueParser.INSTANCE);
+      HeaderElement elem;
+      try {
+        elem = BasicHeaderValueParser.parseHeaderElement(httpHeaderLink,
+            BasicHeaderValueParser.INSTANCE);
+      } catch (ParseException e) {
+        LOG.error("Failed to parse Link HTTP header: {}", httpHeaderLink, e);
+        continue;
+      }
       for (NameValuePair param : elem.getParameters()) {
         if ("rel".equalsIgnoreCase(param.getName())
             && canonicalRelValuePattern.matcher(param.getValue()).find()) {

--- a/src/test/org/commoncrawl/util/TestCanonicalLinkDetector.java
+++ b/src/test/org/commoncrawl/util/TestCanonicalLinkDetector.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commoncrawl.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TestCanonicalLinkDetector {
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "<link href=\"https://www.example.org/canonical/\" rel=\"canonical\"/>", //
+      "<link href=\"https://www.example.org/canonical/\" rel='canonical'/>", //
+      "<link rel=\"canonical\" href=\"https://www.example.org/canonical/\" />", //
+      "<link rel='canonical' href=\"https://www.example.org/canonical/\" />", //
+      "<link   rel=canonical   href=\"https://www.example.org/canonical/\" />", //
+      "<link rel=canonical\r\n       href=\"https://www.example.org/canonical/\" />", //
+      "<link href=\"https://www.example.org/canonical/\"\n       rel=canonical />", //
+      "<link rel=canonical href=https://www.example.org/canonical/ ><!-- HTML5 -->", //
+      "<link rel=canonical href=\"/canonical/\" /><!-- relative URL -->", //
+  })
+  void testDetectHTML(String htmlSnippet) {
+    String canonicalLink = "https://www.example.org/canonical/";
+    List<String> canonicalLinks = CanonicalLinkDetector
+        .detectCanonicalLinksHTML(htmlSnippet.getBytes(StandardCharsets.UTF_8),
+            1024, 1);
+    assertFalse(canonicalLinks.isEmpty());
+    URI baseUri = URI.create("https://www.example.org/");
+    assertEquals(canonicalLink,
+        baseUri.resolve(canonicalLinks.get(0)).toASCIIString());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "<https://www.example.org/canonical/>; rel=\"canonical\"", //
+      "<https://www.example.org/canonical/>; rel=\"canonical\",<https://www.example.org/node/6568/>; rel=\"shortlink\"", //
+      "<https://www.example.org/canonical/>; rel='canonical'", //
+      "<https://www.example.org/canonical/>; rel=\"canonical\",<https://www.example.org/node/8098>; rel=\"shortlink\",<https://www.example.org/db.ico>; rel=\"shortcut icon\"", //
+  })
+  void testDetectHTTP(String httpHeader) {
+    String canonicalLink = "https://www.example.org/canonical/";
+    String[] linkHeaderValues = List.of(httpHeader).toArray(new String[0]);
+    List<String> canonicalLinks = CanonicalLinkDetector
+        .detectCanonicalLinksHttpHeader(linkHeaderValues, 1);
+    assertFalse(canonicalLinks.isEmpty());
+    assertEquals(canonicalLink, canonicalLinks.get(0));
+  }
+}


### PR DESCRIPTION
Canonical links ([1](https://en.wikipedia.org/wiki/Canonical_link_element), [2](https://almanac.httparchive.org/en/2024/seo#canonicalization), [3](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls)) can be used by webmasters to signalize that a page is a duplicate of another one.

Evaluation on a random set of WARC files showed that about 60% of web pages include a canonical link. This observation is similar to those reported in [2](https://almanac.httparchive.org/en/2024/seo#canonicalization) and [4](https://dl.acm.org/doi/10.1145/3404835.3463246).

Requirement is a lazy extraction of canonical links in a Nutch workflow where content is not parsed but only written into WARC files. The links are stored in the CrawlDb and are planned to be used later to reduce the amount of duplicated content.

Design decisions:
- Use a HTTP parser to extract canonical links from HTTP headers
- Scan only the first 64 kiB of HTML content for canonical links. This is not sufficient to extract all canonical links, it's compromise between speed and recall.
- Avoid converting binary HTML content to a Java String, directly scan the content byte array, assuming ASCII / ISO-8859-1 encoding.
- Pass found links to CrawlDb by adding them to the metadata of the fetch CrawlDatum item.

The decisions are rooted in an experimental setup were the canonical link detection was tested on WARC input. Below the evaluation metrics for `CC-MAIN-20240907095856-20240907125856-00058.warc.gz`, with the following parameters:


```
       links           ms      
       found  String BACS 
kiB                           
  1     7468    273   214
  2    11967    407   372
  4    15034    657   546
  8    16617    980   899
 16    18047   1528  1371
 32    19761   2618  2093
 64    20566   3923  2823
128    21009   5481  3722
256    21255   6691  4887
512    21381   7502  4996

                   N = 31498  (documents processed
max. canonical links =     1  (stop after first link found)
```

Using the first 64 kiB gives 96% of the canonical links found in the first 512 kiB, but requiring only 57% of the computation time. Usage of the ByteArrayCharSequence instead of a Java String is a significant performance improvement. The full evaluation metrics: [canonical-link-evaluation-CC-MAIN-20240907095856-20240907125856-0005.tsv](https://github.com/user-attachments/files/23913496/canonical-link-evaluation-CC-MAIN-20240907095856-20240907125856-0005.tsv)

The CrawlDb is expected to grow by 40–60% if it includes canonical links. The 60% growth is inline with the 60% adaption rate of canonical links. In practice, the number is lower because items in the CrawlDb which failed to fetch naturally do not have a canonical link.

Example of a CrawlDb record with canonical link:
```
https://blog.commoncrawl.org/ccbot      Version: 7
Status: 2 (db_fetched)
Fetch time: Wed Dec 10 10:31:58 CET 2025
Modified time: Wed Dec 03 10:31:58 CET 2025
Retries since fetch: 0
Retry interval: 604800 seconds (7 days)
Score: 0.0
Signature: 1097648fedeebc1db8dbe62354b698e8
Metadata: 
        _lst_=29412568
        _pst_=success(1), lastModified=1764367820000
        _rs_=28
        Content-Type=text/html
        nutch.protocol.code=200
        canonical.link=https://commoncrawl.org/ccbot
```
