### PR TITLE
Fix tests `org.commoncrawl.*` being ignored/skipped

### DIFF
--- a/.github/workflows/cc-build.yml
+++ b/.github/workflows/cc-build.yml
@@ -55,3 +55,21 @@ jobs:
           curl https://publicsuffix.org/list/public_suffix_list.dat -o conf/effective_tld_names.dat
       - name: Test
         run: ant clean test -buildfile build.xml
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            ./build/test/TEST-*.xml
+            ./build/**/test/TEST-*.xml
+          retention-days: 1
+      - name: Publish Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            ./build/test/TEST-*.xml
+            ./build/**/test/TEST-*.xml
+          comment_mode: always
+          fail_on: "test failures"

--- a/build.xml
+++ b/build.xml
@@ -503,7 +503,24 @@
           <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
         </fork>
         <fileset dir="${test.build.classes}">
-          <include name="**/Test*.class"/>
+          <include name="org/apache/nutch/**/Test*.class"/>
+          <exclude name="**/${test.exclude}.class"/>
+        </fileset>
+      </testclasses>
+      <!-- org.commoncrawl tests run in their own forked JVM to isolate them
+           from any System.exit() or JVM crashes in the org.apache.nutch batch -->
+      <testclasses outputDir="${test.build.dir}" unless="testcase">
+        <listener type="legacy-plain" sendSysOut="true" sendSysErr="true"/>
+        <listener type="legacy-xml" sendSysOut="true" sendSysErr="true"/>
+        <fork>
+          <jvmarg value="-Xmx1000m"/>
+          <sysproperty key="test.build.data" value="${test.build.data}"/>
+          <sysproperty key="test.src.dir" value="${test.src.dir}"/>
+          <sysproperty key="test.include.slow" value="${test.include.slow}"/>
+          <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
+        </fork>
+        <fileset dir="${test.build.classes}">
+          <include name="org/commoncrawl/**/Test*.class"/>
           <exclude name="**/${test.exclude}.class"/>
         </fileset>
       </testclasses>

--- a/build.xml
+++ b/build.xml
@@ -504,6 +504,7 @@
         </fork>
         <fileset dir="${test.build.classes}">
           <include name="org/apache/nutch/**/Test*.class"/>
+          <include name="org/apache/nutch/**/*Test.class"/>
           <exclude name="**/${test.exclude}.class"/>
         </fileset>
       </testclasses>

--- a/build.xml
+++ b/build.xml
@@ -495,7 +495,7 @@
       <testclasses outputDir="${test.build.dir}" unless="testcase">
         <listener type="legacy-plain" sendSysOut="true" sendSysErr="true"/>
         <listener type="legacy-xml" sendSysOut="true" sendSysErr="true"/>
-        <fork>
+        <fork forkMode="perTestClass">
           <jvmarg value="-Xmx1000m"/>
           <sysproperty key="test.build.data" value="${test.build.data}"/>
           <sysproperty key="test.src.dir" value="${test.src.dir}"/>
@@ -503,25 +503,7 @@
           <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
         </fork>
         <fileset dir="${test.build.classes}">
-          <include name="org/apache/nutch/**/Test*.class"/>
-          <include name="org/apache/nutch/**/*Test.class"/>
-          <exclude name="**/${test.exclude}.class"/>
-        </fileset>
-      </testclasses>
-      <!-- org.commoncrawl tests run in their own forked JVM to isolate them
-           from any System.exit() or JVM crashes in the org.apache.nutch batch -->
-      <testclasses outputDir="${test.build.dir}" unless="testcase">
-        <listener type="legacy-plain" sendSysOut="true" sendSysErr="true"/>
-        <listener type="legacy-xml" sendSysOut="true" sendSysErr="true"/>
-        <fork>
-          <jvmarg value="-Xmx1000m"/>
-          <sysproperty key="test.build.data" value="${test.build.data}"/>
-          <sysproperty key="test.src.dir" value="${test.src.dir}"/>
-          <sysproperty key="test.include.slow" value="${test.include.slow}"/>
-          <sysproperty key="javax.xml.parsers.DocumentBuilderFactory" value="com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl"/>
-        </fork>
-        <fileset dir="${test.build.classes}">
-          <include name="org/commoncrawl/**/Test*.class"/>
+          <include name="**/Test*.class"/>
           <exclude name="**/${test.exclude}.class"/>
         </fileset>
       </testclasses>

--- a/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
+++ b/src/java/org/apache/nutch/tools/CommonCrawlDataDumper.java
@@ -274,7 +274,7 @@ public class CommonCrawlDataDumper extends NutchTool implements Tool {
     if (parts == null || parts.size() == 0) {
       LOG.error( "No segment directories found in {} ",
           segmentRootDir.getAbsolutePath());
-      System.exit(1);
+      return;
     }
     LOG.info("Found {} segment parts", parts.size());
     if (gzip && !warc) {


### PR DESCRIPTION
This PR fixes the problem described in #43 

In short, all test were ran with <fork> and there are two tests in particular `TestCommonCrawlDataDumper.dump()` which calls `System.exit()` dumping the whole forked process. Also `TestMimeUtil` had a similar problem.

For now I've separated the `org.commoncrawl.*` from the `org.apache.*` tests. But the issue may still occur preventing other tests from the same group to be executed. Ideally we shoud avoid the `System.exit` (maybe static mocking?) or make the tests in individual forks. 