### PR TITLE
Enable report for running tests

### DIFF
--- a/.github/workflows/cc-build.yml
+++ b/.github/workflows/cc-build.yml
@@ -55,3 +55,21 @@ jobs:
           curl https://publicsuffix.org/list/public_suffix_list.dat -o conf/effective_tld_names.dat
       - name: Test
         run: ant clean test -buildfile build.xml
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            ./build/test/TEST-*.xml
+            ./build/**/test/TEST-*.xml
+          retention-days: 1
+      - name: Publish Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            ./build/test/TEST-*.xml
+            ./build/**/test/TEST-*.xml
+          comment_mode: always
+          fail_on: "test failures"


### PR DESCRIPTION
This PR attempt to provide a view on the tests that are running to compare #44. We could merge it already IMHO. 